### PR TITLE
[processor] Prevent accidental calls to global functions

### DIFF
--- a/src/Processor/CallableContextProcessor.php
+++ b/src/Processor/CallableContextProcessor.php
@@ -27,7 +27,7 @@ class CallableContextProcessor implements ProcessorInterface
 		}
 
 		foreach ($context as $key => &$value) {
-			if (\is_callable($value)) {
+			if (!is_string($value) && \is_callable($value)) {
 				try {
 					$value = $value();
 				}

--- a/tests/Processor/CallableContextTest.php
+++ b/tests/Processor/CallableContextTest.php
@@ -60,4 +60,29 @@ final class CallableContextTest extends TestCase
 
 		$this->assertTrue($callbackExecuted);
 	}
+
+	public function testStringFunctionIsNotCalled():void
+	{
+		$stringFunction  = 'Stefna\Logger\Processor\testingFunction';
+
+		$mainLogger = $this->createMock(LoggerInterface::class);
+		$logger = new ProcessLogger($mainLogger, new CallableContextProcessor());
+		$msg = 'testCallbackValueIsRemoved';
+		$callbackExecuted = false;
+
+		$this->expectOutputString("");
+		$logger->debug($msg, [
+			"section" => $stringFunction,
+			CallableContextProcessor::CALLBACK => function () use (&$callbackExecuted) {
+				$callbackExecuted = true;
+			},
+		]);
+
+		$this->assertTrue($callbackExecuted);
+	}
+}
+
+function testingFunction()
+{
+	print("should not print this");
 }


### PR DESCRIPTION
if any of the values is the string 'header' or 'die' then that global function gets called.
This should be done explicitly if indended.

Issue: MOYA-1244